### PR TITLE
use WP_Query for excluded Posts and Pages Fix hide post

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,11 @@
 == Changelog ==
 
+= 0.8.7 =
+
+*Release date: October 24, 2020*
+
+* Bugfix for not using the right url of a blog post when permalink was customized
+
 = 0.8.6 =
 
 *Release date: October 8, 2020*

--- a/list-last-changes.php
+++ b/list-last-changes.php
@@ -64,24 +64,18 @@ class ListLastChangesWidget extends WP_Widget {
 	public static function generate_list(int $number, bool $showpages, bool $showposts, string $template) : string {
 		$content = " <ul>\n";
 		
-		$excludePages = ListLastChangesWidget::wp_get_pages(array('meta_key' => 'list_last_changes_ignore', 'meta_value' => 'true', 'hierarchical' => 0));
+		$loop = new WP_Query(array('post_type' => 'page', 'meta_key' => 'list_last_changes_ignore', 'meta_value' => 'true', 'numberposts' => -1));
 		$excludePageIds = "";
-		if(is_array($excludePages)) {
-			for($i = 0; $i < count($excludePages); $i++) {
-				if($i > 0) {
-					$excludePageIds = $excludePageIds . ",";
-				}
-				$excludePageIds = $excludePageIds . $excludePages[$i]->ID;
-			}
+		while( $loop->have_posts() ) {
+			$loop->the_post();
+			$excludePageIds = $excludePageIds . get_the_ID() . ",";
 		}
 
-		$excludePosts = get_posts(array('meta_key' => 'list_last_changes_ignore', 'meta_value' => 'true', 'numberposts' => -1));
+		$loop = new WP_Query(array('post_type' => 'post', 'meta_key' => 'list_last_changes_ignore', 'meta_value' => 'true', 'numberposts' => -1));
 		$excludePostIds = "";
-		for($i = 0; $i < count($excludePosts); $i++) {
-			if($i > 0) {
-				$excludePostIds = $excludePostIds . ",";
-			}
-			$excludePostIds = $excludePostIds . $excludePosts[$i]->ID;
+		while( $loop->have_posts() ) {
+			$loop->the_post();
+			$excludePostIds = $excludePostIds . get_the_ID() . ",";
 		}
 
 		$mypages = array();
@@ -131,6 +125,9 @@ class ListLastChangesWidget extends WP_Widget {
 		}
 
 		$content = $content . " </ul>\n";
+
+		wp_reset_postdata();
+
 		return $content;
 	}
 

--- a/list-last-changes.php
+++ b/list-last-changes.php
@@ -3,14 +3,14 @@
  * Plugin Name: List Last Changes
  * Plugin URI: http://www.rolandbaer.ch/software/wordpress/plugin-last-changes/
  * Description: Shows a list of the last changes of a WordPress site.
- * Version: 1.0.1
+ * Version: 1.0.2
  * Author: Roland Bär
  * Author URI: http://www.rolandbaer.ch/
  * Text Domain: list-last-changes
  * License: GPLv3
  */
 
-/*  Copyright 2013-2022  Roland Bär  (email : info@rolandbaer.ch)
+/*  Copyright 2013-2023  Roland Bär  (email : info@rolandbaer.ch)
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License, version 3, as 

--- a/readme.txt
+++ b/readme.txt
@@ -66,6 +66,12 @@ Sample templates:
 
 == Changelog ==
 
+= 1.0.2 =
+
+*Release date: November 07, 2023*
+
+* Bugfix for interference with other plugins. Uses now the method WP_Query to get the posts and pages to ignore
+
 = 1.0.1 =
 
 *Release date: September 05, 2022*
@@ -92,12 +98,6 @@ Sample templates:
 *Release date: November 29, 2020*
 
 * Introducing template mechanism in shortcode (also planned for widget and block)
-
-= 0.8.7 =
-
-*Release date: October 24, 2020*
-
-* Bugfix for not using the right url of a blog post when permalink was customized
 
 = Older releases =
 see [additional changelog.txt file](https://plugins.svn.wordpress.org/list-last-changes/trunk/changelog.txt)

--- a/readme.txt
+++ b/readme.txt
@@ -3,11 +3,11 @@ Contributors: rbaer, osthafen
 Tags: last changes, pages, posts, widget, shortcode, block editor
 Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=PRW4QXZ3DHWL6&lc=GB&item_name=List%20Last%20Changes%20Plugin&currency_code=EUR&bn=PP%2dDonationsBF%3abtn_donateCC_LG_global%2egif%3aNonHosted
 Requires at least: 4.6.0
-Tested up to: 6.3
+Tested up to: 6.4
 Requires PHP: 7.0
 License: GPLv3 or later
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
-Stable tag: 1.0.1
+Stable tag: 1.0.2
 
 Shows a list of the last changes of a WordPress site.
 


### PR DESCRIPTION
avoids problems with other WordPress plugins that change the WP_Query of the get_posts method (via hook).