### PR TITLE
Bugfix for regression of 1.0.2

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,13 @@
 == Changelog ==
 
+= 1.0.0 =
+
+*Release date: December 09, 2020*
+
+* Introducing template mechanism in the block editor 
+* The configuration field 'show author' in the block editor is replaced by the template mechanism
+* The template mechanism is now "feature complete"
+
 = 0.9.5 =
 
 *Release date: December 08, 2020*

--- a/list-last-changes.php
+++ b/list-last-changes.php
@@ -3,7 +3,7 @@
  * Plugin Name: List Last Changes
  * Plugin URI: http://www.rolandbaer.ch/software/wordpress/plugin-last-changes/
  * Description: Shows a list of the last changes of a WordPress site.
- * Version: 1.0.4
+ * Version: 1.0.5
  * Author: Roland Bär
  * Author URI: http://www.rolandbaer.ch/
  * Text Domain: list-last-changes
@@ -64,14 +64,14 @@ class ListLastChangesWidget extends WP_Widget {
 	public static function generate_list($number, $showpages, $showposts, $template) {
 		$content = " <ul>\n";
 
-		$loop = new WP_Query(array('post_type' => 'page', 'meta_key' => 'list_last_changes_ignore', 'meta_value' => 'true', 'numberposts' => -1));
+		$loop = new WP_Query(array('post_type' => 'page', 'meta_key' => 'list_last_changes_ignore', 'meta_value' => 'true', 'posts_per_page' => -1));
 		$excludePageIds = "";
 		while( $loop->have_posts() ) {
 			$loop->the_post();
 			$excludePageIds = $excludePageIds . get_the_ID() . ",";
 		}
 
-		$loop = new WP_Query(array('post_type' => 'post', 'meta_key' => 'list_last_changes_ignore', 'meta_value' => 'true', 'numberposts' => -1));
+		$loop = new WP_Query(array('post_type' => 'post', 'meta_key' => 'list_last_changes_ignore', 'meta_value' => 'true', 'posts_per_page' => -1));
 		$excludePostIds = "";
 		while( $loop->have_posts() ) {
 			$loop->the_post();

--- a/readme.txt
+++ b/readme.txt
@@ -6,7 +6,7 @@ Requires at least: 4.6.0
 Tested up to: 6.4
 License: GPLv3 or later
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
-Stable tag: 1.0.4
+Stable tag: 1.0.5
 
 Shows a list of the last changes of a WordPress site.
 
@@ -65,11 +65,17 @@ Sample templates:
 
 == Changelog ==
 
+= 1.0.5 =
+
+*Release date: November 12, 2023*
+
+* Bugfix for limit the ignored pages or posts to the number of posts per page (regression of 1.0.2).
+
 = 1.0.4 =
 
 *Release date: November 11, 2023*
 
-* Bugfixx for block editor support: adapted to changes in the block editor handling
+* Bugfix for block editor support: adapted to changes in the block editor handling
 
 = 1.0.3 =
 
@@ -88,14 +94,6 @@ Sample templates:
 *Release date: September 05, 2022*
 
 * Bugfix for exclude only up to five posts 
-
-= 1.0.0 =
-
-*Release date: December 09, 2020*
-
-* Introducing template mechanism in the block editor 
-* The configuration field 'show author' in the block editor is replaced by the template mechanism
-* The template mechanism is now "feature complete"
 
 = Older releases =
 see [additional changelog.txt file](https://plugins.svn.wordpress.org/list-last-changes/trunk/changelog.txt)


### PR DESCRIPTION
Bugfix for limit the ignored pages or posts to the number of posts per page (regression of 1.0.2).