### PR TITLE
Support for editor of the latest change in the template

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,11 @@
 == Changelog ==
 
+= 1.0.1 =
+
+*Release date: September 05, 2022*
+
+* Bugfix for exclude only up to five posts 
+
 = 1.0.0 =
 
 *Release date: December 09, 2020*

--- a/list-last-changes.php
+++ b/list-last-changes.php
@@ -101,7 +101,8 @@ class ListLastChangesWidget extends WP_Widget {
 			$transitions = array(
 				"{title}" => '<a href="' . get_permalink( $post->ID ) .'">' . $post->post_title . "</a>",
 				"{change_date}" => '<span class="list_last_changes_date">' . date_i18n(get_option('date_format') ,strtotime($post->post_modified)) . "</span>",
-				"{author}" => '<span class="list_last_changes_author">' . get_the_author_meta( 'display_name' , $post->post_author ) . "</span>");
+				"{author}" => '<span class="list_last_changes_author">' . get_the_author_meta( 'display_name' , $post->post_author ) . "</span>",
+				"{editor}" => '<span class="list_last_changes_author">' . ListLastChangesWidget::get_last_editor($post) . "</span>");
 			$entry = strtr($template, $transitions);
 			$content = $content . '  <li class="list_last_changes_title">'. "\n" ;
 			$content = $content . $entry;
@@ -113,6 +114,16 @@ class ListLastChangesWidget extends WP_Widget {
 		wp_reset_postdata();
 
 		return $content;
+	}
+
+	static function get_last_editor($post) {
+		$last_editor_id = get_post_meta( $post->ID, '_edit_last', true );
+
+		if ( $last_editor_id ) {
+			$last_user = get_userdata( $last_editor_id );
+
+			return apply_filters( 'the_modified_author', $last_user ? $last_user->display_name : '' );
+		}
 	}
 
 	function update( $new_instance, $old_instance ) {

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: rbaer, osthafen
 Tags: last changes, pages, posts, widget, shortcode, block editor
 Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=PRW4QXZ3DHWL6&lc=GB&item_name=List%20Last%20Changes%20Plugin&currency_code=EUR&bn=PP%2dDonationsBF%3abtn_donateCC_LG_global%2egif%3aNonHosted
 Requires at least: 4.6.0
-Tested up to: 6.4
+Tested up to: 6.5
 License: GPLv3 or later
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 Stable tag: 1.0.5

--- a/readme.txt
+++ b/readme.txt
@@ -66,6 +66,12 @@ Sample templates:
 
 == Changelog ==
 
+= 1.x.x =
+
+*Release date: <tbd>*
+
+* new field {editor} in the template string to show the last editor of the page or post
+
 = 1.0.5 =
 
 *Release date: November 12, 2023*
@@ -89,12 +95,6 @@ Sample templates:
 *Release date: November 07, 2023*
 
 * Bugfix for interference with other plugins. Uses now the method WP_Query to get the posts and pages to ignore
-
-= 1.0.1 =
-
-*Release date: September 05, 2022*
-
-* Bugfix for exclude only up to five posts 
 
 = Older releases =
 see [additional changelog.txt file](https://plugins.svn.wordpress.org/list-last-changes/trunk/changelog.txt)

--- a/readme.txt
+++ b/readme.txt
@@ -19,7 +19,7 @@ Additional features include:
 
 * Select the number of entries in the list
 * Define pages to be excluded
-* Show the author of the page/post
+* Show the author or the last editor of the page/post
 
 = Exclude page or post =
 To exclude a page or post from being listed in the widget do the following steps:
@@ -53,10 +53,11 @@ In difference to the widget, with the shortcode no title is written. If a title 
 
 = Templates =
 
-In the template string the following fields can be used: {title}, {change_date} and {author}.
+In the template string the following fields can be used: {title}, {change_date}, {author} and {editor}.
 {title} : the title of the page or post with a link to it
 {change_date} : the date the page or post was changed
 {author} : the author of the page or post
+{editor} : the last editor of the page or post
 
 Sample templates:
 {title} {change_date} : the default template


### PR DESCRIPTION
* updated "Tested up to"
* new field {editor} in the template string to show the last editor of the page or post

fixes #29 