### PR TITLE
fix for wrong user name of editor field

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,11 @@
 == Changelog ==
 
+= 1.0.3 =
+
+*Release date: November 08, 2023*
+
+* Bugfix for 1.0.2: removed refactorings (type information) that occured errors with some older php versions
+
 = 1.0.2 =
 
 *Release date: November 07, 2023*

--- a/list-last-changes.php
+++ b/list-last-changes.php
@@ -127,31 +127,16 @@ class ListLastChangesWidget extends WP_Widget {
 
 	static function get_last_editor($post) {
 		$last_editor_id = null;
-		// first try: use metadata _edit_lock
-		$lock = get_post_meta( $post->ID, '_edit_lock', true );
-		if ( $lock ) {
-			$lock = explode( ':', $lock );
-			if (isset( $lock[1] )) {
-				$last_editor_id = $lock[1];
-			}
+
+		// get author of latest revision
+		$revisions = wp_get_post_revisions($post);
+		if(count($revisions) > 0) {
+			$rev = reset($revisions);
+			$last_editor_id = $rev->post_author;
 		}
 
 		if( !$last_editor_id) {
-			// first fallback: use metadata _edit_last
-			$last_editor_id = get_post_meta( $post->ID, '_edit_last', true );
-		}
-
-		if( !$last_editor_id) {
-			// second fallback: get author of latest revision
-			$revisions = wp_get_post_revisions($post);
-			if(count($revisions) > 0) {
-				$rev = reset($revisions);
-				$last_editor_id = $rev->post_author;
-			}
-		}
-
-		if( !$last_editor_id) {
-			// last fallback: use post_author
+			// fallback: use post_author
 			$last_editor_id = $post->post_author;
 		}
 

--- a/list-last-changes.php
+++ b/list-last-changes.php
@@ -3,7 +3,7 @@
  * Plugin Name: List Last Changes
  * Plugin URI: http://www.rolandbaer.ch/software/wordpress/plugin-last-changes/
  * Description: Shows a list of the last changes of a WordPress site.
- * Version: 1.1.1
+ * Version: 1.1.2
  * Author: Roland Bär
  * Author URI: http://www.rolandbaer.ch/
  * Text Domain: list-last-changes

--- a/readme.txt
+++ b/readme.txt
@@ -6,7 +6,7 @@ Requires at least: 4.6.0
 Tested up to: 6.6
 License: GPLv3 or later
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
-Stable tag: 1.1.1
+Stable tag: 1.1.2
 
 Shows a list of the last changes of a WordPress site.
 
@@ -69,6 +69,12 @@ Sample templates:
 
 == Changelog ==
 
+= 1.1.2 =
+
+*Release date: September 13, 2024*
+
+* fix for wrong user name of editor field under some circumstances
+
 = 1.1.1 =
 
 *Release date: July 13, 2024*
@@ -94,12 +100,6 @@ Sample templates:
 *Release date: November 11, 2023*
 
 * Bugfix for block editor support: adapted to changes in the block editor handling
-
-= 1.0.3 =
-
-*Release date: November 08, 2023*
-
-* Bugfix for 1.0.2: removed refactorings (type information) that occured errors with some older php versions
 
 = Older releases =
 see [additional changelog.txt file](https://plugins.svn.wordpress.org/list-last-changes/trunk/changelog.txt)


### PR DESCRIPTION
fix for wrong user name of editor field under some circumstances

don't use postmeta data _edit_last but the user information of the latest revision or of the post.