### PR TITLE
bugfix for missing span on formated date

### DIFF
--- a/src/changelog.txt
+++ b/src/changelog.txt
@@ -1,5 +1,11 @@
 == Changelog ==
 
+= 1.1.1 =
+
+*Release date: July 13, 2024*
+
+* Small quality fixes (from static code analyzer)
+
 = 1.1.0 =
 
 *Release date: April 23, 2024*

--- a/src/list-last-changes.php
+++ b/src/list-last-changes.php
@@ -3,7 +3,7 @@
  * Plugin Name: List Last Changes
  * Plugin URI: http://www.rolandbaer.ch/software/wordpress/plugin-last-changes/
  * Description: Shows a list of the last changes of a WordPress site.
- * Version: 1.2.2
+ * Version: 1.2.3
  * Author: Roland Bär
  * Author URI: http://www.rolandbaer.ch/
  * Text Domain: list-last-changes
@@ -108,10 +108,10 @@ class ListLastChangesWidget extends WP_Widget {
 			setup_postdata($post);
 			$transitions = array(
 				"{title}" => '<a href="' . get_permalink( $post->ID ) .'">' . $post->post_title . "</a>",
-				"{change_date}" => '<span class="list_last_changes_date">' . date_i18n(get_option('date_format'), strtotime($post->post_modified)) . "</span>",
-				"{published_date}" => '<span class="list_last_changes_date">' . date_i18n(get_option('date_format'), strtotime($post->post_date)) . "</span>",
-				"{author}" => '<span class="list_last_changes_author">' . get_the_author_meta( 'display_name', $post->post_author ) . "</span>",
-				"{editor}" => '<span class="list_last_changes_author">' . ListLastChangesWidget::get_last_editor($post) . "</span>");
+				"{change_date}" => ListLastChangesWidget::span_class(date_i18n(get_option('date_format'), strtotime($post->post_modified)), "list_last_changes_date"),
+				"{published_date}" => ListLastChangesWidget::span_class(date_i18n(get_option('date_format'), strtotime($post->post_date)), "list_last_changes_date"),
+				"{author}" => ListLastChangesWidget::span_class(get_the_author_meta( 'display_name', $post->post_author ), "list_last_changes_author"),
+				"{editor}" => ListLastChangesWidget::span_class(ListLastChangesWidget::get_last_editor($post), "list_last_changes_author") );
 			$entry = strtr(esc_attr($template), $transitions);
 			$entry = ListLastChangesWidget::replace_date_format("change_date", $entry, strtotime($post->post_modified));
 			$entry = ListLastChangesWidget::replace_date_format("published_date", $entry, strtotime($post->post_date));
@@ -130,10 +130,15 @@ class ListLastChangesWidget extends WP_Widget {
 	public static function replace_date_format($date_name, $input, $date_time) {
 		$pattern = "/\{$date_name\[([^\]]*)\]\}/i";
 		if(preg_match($pattern, $input, $matches)) {
-			$input = preg_replace($pattern, date_i18n("$matches[1]", $date_time), $input);
+			$input = preg_replace($pattern, ListLastChangesWidget::span_class(date_i18n("$matches[1]", $date_time), "list_last_changes_date"), $input);
 		}
 
 		return $input;
+	}
+
+	public static function span_class($input, $class)
+	{
+		return '<span class="' . $class. '">' . $input . '</span>';
 	}
 
 	static function get_last_editor($post) {

--- a/src/readme.txt
+++ b/src/readme.txt
@@ -3,10 +3,10 @@ Contributors: rbaer, osthafen
 Tags: last changes, widget, shortcode, block editor
 Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=PRW4QXZ3DHWL6&lc=GB&item_name=List%20Last%20Changes%20Plugin&currency_code=EUR&bn=PP%2dDonationsBF%3abtn_donateCC_LG_global%2egif%3aNonHosted
 Requires at least: 4.6.0
-Tested up to: 6.7
+Tested up to: 6.8
 License: GPLv3 or later
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
-Stable tag: 1.2.2
+Stable tag: 1.2.3
 
 Shows a list of the last changes of a WordPress site.
 
@@ -73,6 +73,12 @@ Sample templates:
 
 == Changelog ==
 
+= 1.2.3 =
+
+*Release date: April 25, 2025*
+
+* fixed bug that a date with a defined date format was missing the surrounding span tag to style it via css
+
 = 1.2.2 =
 
 *Release date: April 17, 2025*
@@ -96,12 +102,6 @@ Sample templates:
 *Release date: September 13, 2024*
 
 * fix for wrong user name of editor field under some circumstances
-
-= 1.1.1 =
-
-*Release date: July 13, 2024*
-
-* Small quality fixes (from static code analyzer)
 
 = Older releases =
 see [additional changelog.txt file](https://plugins.svn.wordpress.org/list-last-changes/trunk/changelog.txt)


### PR DESCRIPTION
fixed bug that a date with a defined date format was missing the surrounding span tag to style it via css

fixes #50 